### PR TITLE
Migrate to SDL3

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -62,12 +62,12 @@ jobs:
         if: github.event.inputs.upload_lib == 'true' || github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: 'libengine.a'
+          name: 'engine_linux_${{github.run_number}}'
           path: '${{github.workspace}}/cmake-build-debug/engine/libengine.a'
 
       - name: 'Upload game'
         if: github.event.inputs.upload_game == 'true' || github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: 'game_${{github.run_number}}'
+          name: 'game_linux_${{github.run_number}}'
           path: '${{github.workspace}}/cmake-build-debug/game'

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: 'Build SDL2'
         run: |
-          git clone https://github.com/libsdl-org/SDL.git -b SDL2
+          git clone https://github.com/libsdl-org/SDL.git -b main
           cd SDL
           mkdir build
           cd build
@@ -45,7 +45,7 @@ jobs:
 
       - name: 'Build SDL2_image'
         run: |
-          git clone https://github.com/libsdl-org/SDL_image.git -b SDL2
+          git clone https://github.com/libsdl-org/SDL_image.git -b main
           cd SDL_image
           mkdir build
           cd build

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt update
           sudo apt install ninja-build -y
 
-      - name: 'Build SDL2'
+      - name: 'Build SDL3'
         run: |
           git clone https://github.com/libsdl-org/SDL.git -b main
           cd SDL
@@ -43,7 +43,7 @@ jobs:
           cmake --build . --config Release -j 6
           sudo cmake --install . --config Release
 
-      - name: 'Build SDL2_image'
+      - name: 'Build SDL3_image'
         run: |
           git clone https://github.com/libsdl-org/SDL_image.git -b main
           cd SDL_image

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,27 +30,27 @@ jobs:
 
       - name: 'Build SDL2'
         run: |
-          git clone https://github.com/libsdl-org/SDL.git -b SDL2
+          git clone https://github.com/libsdl-org/SDL.git -b main
           cd SDL
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/SDL2
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/SDL3
           cmake --build . --config Release -j 6
           cmake --install . --config Release
 
       - name: 'Build SDL2_image'
         run: |
-          git clone https://github.com/libsdl-org/SDL_image.git -b SDL2
+          git clone https://github.com/libsdl-org/SDL_image.git -b main
           cd SDL_image
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/SDL2
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/SDL3
           cmake --build . --config Release -j 6
           cmake --install . --config Release
 
       - name: 'Build'
         run: |
-          cmake -DCMAKE_PREFIX_PATH=${{github.workspace}}/SDL2 -DCMAKE_BUILD_TYPE=Debug -S ${{github.workspace}} -B ${{github.workspace}}/cmake-build-debug
+          cmake -DCMAKE_PREFIX_PATH=${{github.workspace}}/SDL3 -DCMAKE_BUILD_TYPE=Debug -S ${{github.workspace}} -B ${{github.workspace}}/cmake-build-debug
           cmake --build ${{github.workspace}}/cmake-build-debug --target game -j 6
 
       - name: 'Upload engine library'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: 'Build SDL2'
+      - name: 'Build SDL3'
         run: |
           git clone https://github.com/libsdl-org/SDL.git -b main
           cd SDL
@@ -38,7 +38,7 @@ jobs:
           cmake --build . --config Release -j 6
           cmake --install . --config Release
 
-      - name: 'Build SDL2_image'
+      - name: 'Build SDL3_image'
         run: |
           git clone https://github.com/libsdl-org/SDL_image.git -b main
           cd SDL_image

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -57,12 +57,12 @@ jobs:
         if: github.event.inputs.upload_lib == 'true' || github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: 'libengine.a'
+          name: 'engine_win64_${{github.run_number}}'
           path: '${{github.workspace}}/cmake-build-debug/engine/Debug/engine.lib'
 
       - name: 'Upload game'
         if: github.event.inputs.upload_game == 'true' || github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: 'game_${{github.run_number}}'
+          name: 'game_win64_${{github.run_number}}'
           path: '${{github.workspace}}/cmake-build-debug/Debug/game.exe'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(SDL2 REQUIRED)
+find_package(SDL3 REQUIRED)
 
-include_directories(SDL2Test ${SDL2_INCLUDE_DIRS})
+include_directories(SDL3Test ${SDL3_INCLUDE_DIRS})
 include_directories(engine/include)
 include_directories(game_src)
 
@@ -21,4 +21,4 @@ add_executable(game game_src/main.cpp
         game_src/GameApplication.cpp
 )
 
-target_link_libraries(game engine ${SDL2_LIBRARIES} SDL2_image)
+target_link_libraries(game engine ${SDL3_LIBRARIES} SDL3_image)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,4 +11,4 @@ add_library(engine
         src/sprite/BuildingSprite.cpp
 )
 
-target_link_libraries(engine ${SDL2_LIBRARIES} SDL2_image)
+target_link_libraries(engine ${SDL3_LIBRARIES} SDL3_image)

--- a/engine/include/TextureStorage.h
+++ b/engine/include/TextureStorage.h
@@ -8,8 +8,8 @@
 #include <string>
 #include <map>
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
+#include <SDL3/SDL.h>
+#include <SDL3_image/SDL_image.h>
 
 namespace Game {
     class RendererWindow;
@@ -20,7 +20,6 @@ namespace Game {
         ~TextureStorage();
 
         bool load(const std::string& objectName, const std::string &texturePath);
-        void unload(const std::string &objectName);
         SDL_Texture* get(const std::string &objectName);
 
     private:

--- a/engine/include/object/Object.h
+++ b/engine/include/object/Object.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include <utility>
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 namespace Game {
     class RendererWindow;

--- a/engine/include/sprite/Sprite.h
+++ b/engine/include/sprite/Sprite.h
@@ -5,7 +5,7 @@
 #ifndef ENGINE_SPRITE_H
 #define ENGINE_SPRITE_H
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 #include "RendererWindow.h"
 
@@ -35,7 +35,7 @@ namespace Game {
         int size_multiplier_{};
         SDL_Texture *texture_{};
 
-        SDL_Rect src_{};
+        SDL_FRect src_{};
         SDL_FRect dst_{};
 
     private:

--- a/engine/src/RendererWindow.cpp
+++ b/engine/src/RendererWindow.cpp
@@ -2,14 +2,15 @@
 // Created by dmytro-nedavnii on 12/26/23.
 //
 
+#include <iostream>
 #include "RendererWindow.h"
 #include "object/Object.h"
 #include "object/Player.h"
 
 namespace Game {
     RendererWindow::RendererWindow(const std::string &windowName, int width, int height)
-        : window_{SDL_CreateWindow(windowName.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_SHOWN)},
-          renderer_{SDL_CreateRenderer(window_, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC)},
+        : window_{SDL_CreateWindow(windowName.c_str(), width, height, SDL_EVENT_WINDOW_SHOWN)},
+          renderer_{SDL_CreateRenderer(window_, nullptr, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC)},
           storage_{*this}
     {
 
@@ -31,7 +32,7 @@ namespace Game {
             display();
         }
 
-        SDL_Quit();
+        atexit(SDL_Quit);
 
         return 0;
     }
@@ -65,13 +66,13 @@ namespace Game {
     void RendererWindow::handleEvents() {
         while (SDL_PollEvent(&event_)) {
             switch (event_.type) {
-                case SDL_QUIT:
+                case SDL_EVENT_QUIT:
                     is_running_ = false;
                     break;
-                case SDL_KEYDOWN:
+                case SDL_EVENT_KEY_DOWN:
                     handleKeyboard();
                     break;
-                case SDL_KEYUP:
+                case SDL_EVENT_KEY_UP:
 //                        handleKeyboardRelease();
                     break;
 //                case SDL_MOUSEMOTION:
@@ -79,7 +80,7 @@ namespace Game {
 //                    motion_.y = event_.motion.y;
 //                    handleMouse();
 //                    break;
-                case SDL_MOUSEBUTTONDOWN:
+                case SDL_EVENT_MOUSE_BUTTON_DOWN:
                     handleMouse();
                     break;
             }

--- a/engine/src/TextureStorage.cpp
+++ b/engine/src/TextureStorage.cpp
@@ -28,12 +28,6 @@ namespace Game {
         return true;
     }
 
-    void TextureStorage::unload(const std::string &objectName) {
-        auto it = textures_.find(objectName);
-        SDL_DestroyTexture(it->second);
-        textures_.erase(it);
-    }
-
     SDL_Texture *TextureStorage::get(const std::string &objectName) {
         auto it = textures_.find(objectName);
         if (it != textures_.end()) return it->second;

--- a/engine/src/sprite/Sprite.cpp
+++ b/engine/src/sprite/Sprite.cpp
@@ -26,7 +26,7 @@ namespace Game {
 
     SDL_FPoint Sprite::getClampedCoordinates(SDL_FPoint point) {
         int windowWidth, windowHeight;
-        SDL_GetRendererOutputSize(renderer_window_.getRenderer(), &windowWidth, &windowHeight);
+        SDL_GetCurrentRenderOutputSize(renderer_window_.getRenderer(), &windowWidth, &windowHeight);
 
         SDL_FPoint clamped;
         clamped.x = std::clamp(point.x, 0.f, windowWidth - dst_.w);
@@ -36,7 +36,7 @@ namespace Game {
 
     SDL_FPoint Sprite::getClampedCenterCoordinates(SDL_FPoint point) {
         int windowWidth, windowHeight;
-        SDL_GetRendererOutputSize(renderer_window_.getRenderer(), &windowWidth, &windowHeight);
+        SDL_GetCurrentRenderOutputSize(renderer_window_.getRenderer(), &windowWidth, &windowHeight);
 
         SDL_FPoint clamped;
         clamped.x = std::clamp(point.x, 0.f + dst_.w * 0.5f, windowWidth - dst_.w * 0.5f);
@@ -45,10 +45,10 @@ namespace Game {
     }
 
     void Sprite::display() {
-        SDL_RenderCopyF(renderer_window_.getRenderer(), texture_, &src_, &dst_);
+        SDL_RenderTexture(renderer_window_.getRenderer(), texture_, &src_, &dst_);
     }
 
     bool Sprite::collisionWith(const Sprite& other) {
-        return SDL_HasIntersectionF(&dst_, &other.dst_);
+        return SDL_HasRectIntersectionFloat(&dst_, &other.dst_);
     }
 } // Game

--- a/game_src/main.cpp
+++ b/game_src/main.cpp
@@ -4,7 +4,7 @@
 
 #include <iostream>
 #include <SDL3/SDL.h>
-#include <SDL3/SDL_main.h>
+//#include <SDL3/SDL_main.h>
 #include <SDL3_image/SDL_image.h>
 //#undef main
 

--- a/game_src/main.cpp
+++ b/game_src/main.cpp
@@ -3,9 +3,10 @@
 //
 
 #include <iostream>
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
-#undef main
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+#include <SDL3_image/SDL_image.h>
+//#undef main
 
 #include "GameApplication.h"
 


### PR DESCRIPTION
# Reason:
- The hard way to create modal windows on Linux and impossible on Windows with SDL2. This make future development harder.

# What:
- All of code migrated to SDL3.
- Update cmake.
- Update CI/CD (#4).